### PR TITLE
Update NovaInlineRelationshipRequest.php

### DIFF
--- a/src/NovaInlineRelationshipRequest.php
+++ b/src/NovaInlineRelationshipRequest.php
@@ -10,20 +10,6 @@ use Laravel\Nova\Http\Requests\NovaRequest;
 class NovaInlineRelationshipRequest extends NovaRequest
 {
     /**
-     * {@inheritdoc}
-     */
-    public function duplicate(
-        array $query = null,
-        array $request = null,
-        array $attributes = null,
-        array $cookies = null,
-        array $files = null,
-        array $server = null
-    ) {
-        return parent::duplicate($query, $request, $attributes, $cookies, $files, $server);
-    }
-
-    /**
      * Update list of converted files
      *
      * @param Collection $files


### PR DESCRIPTION
removed useless function which causes parental errors with php8.1